### PR TITLE
Add extracurricular certificates CRUD and frontend editor integration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,32 +1,35 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Debug Container",
-            "type": "coreclr",
-            "request": "attach",
-            "preLaunchTask": "Docker Compose: Up",
-            "postDebugTask": "Docker Compose: Down",
-            "pipeTransport": {
-                "pipeProgram": "docker",
-                "pipeArgs": [
-                    "exec",
-                    "-i",
-                    "resumi-backend"
-                ],
-                "debuggerPath": "/vsdbg/vsdbg",
-                "quoteArgs": false
-            },
-            "sourceFileMap": {
-                "/src/backend/Resumi": "${workspaceFolder}/backend/Resumi",
-                "/app": "${workspaceFolder}/backend/Resumi"
-            },
-            "targetArchitecture": "x86_64",
-            "requireExactSource": false,
-            "justMyCode": true
-        }
-    ]
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Debug Container",
+			"type": "coreclr",
+			"request": "attach",
+			"preLaunchTask": "Docker Compose: Up",
+			"postDebugTask": "Docker Compose: Down",
+			"pipeTransport": {
+				"pipeProgram": "docker",
+				"pipeArgs": [
+					"exec",
+					"-i",
+					"resumi-backend"
+				],
+				"debuggerPath": "/vsdbg/vsdbg",
+				"quoteArgs": false
+			},
+			"sourceFileMap": {
+				"/src/backend/Resumi": "${workspaceFolder}/backend/Resumi",
+				"/app": "${workspaceFolder}/backend/Resumi"
+			},
+			"targetArchitecture": "x86_64",
+			"requireExactSource": false,
+			"justMyCode": true,
+			"logging": {
+				"moduleLoad": false,
+			}
+		}
+	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,15 +1,15 @@
 {
-	// Use IntelliSense to learn about possible attributes.
-	// Hover to view descriptions of existing attributes.
-	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"name": "Debug Container",
+			"name": "Debug Container (launch)",
 			"type": "coreclr",
-			"request": "attach",
+			"request": "launch",
 			"preLaunchTask": "Docker Compose: Up",
 			"postDebugTask": "Docker Compose: Down",
+			"program": "/app/Resumi.dll",
+			"cwd": "/app",
+			"args": [],
 			"pipeTransport": {
 				"pipeProgram": "docker",
 				"pipeArgs": [
@@ -24,11 +24,11 @@
 				"/src/backend/Resumi": "${workspaceFolder}/backend/Resumi",
 				"/app": "${workspaceFolder}/backend/Resumi"
 			},
-			"targetArchitecture": "x86_64",
-			"requireExactSource": false,
+			"stopAtEntry": false,
 			"justMyCode": true,
+			"requireExactSource": false,
 			"logging": {
-				"moduleLoad": false,
+				"moduleLoad": false
 			}
 		}
 	]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,24 +1,24 @@
 {
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "Docker Compose: Build",
-            "type": "shell",
-            "command": "docker compose -f ${workspaceFolder}/compose.yml build --no-cache"
-        },
-        {
-            "label": "Docker Compose: Up",
-            "type": "shell",
-            "dependsOn": "Docker Compose: Build",
-            "command": "docker compose -f ${workspaceFolder}/compose.yml up -d"
-        },
-        {
-            "label": "Docker Compose: Down",
-            "type": "shell",
-            "command": "docker compose -f ${workspaceFolder}/compose.yml down",
-            "presentation": {
-                "reveal": "never",
-            }
-        }
-    ]
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Docker Compose: Build",
+			"type": "shell",
+			"command": "docker compose -f ${workspaceFolder}/compose.yml -f ${workspaceFolder}/compose.debug.yml build --no-cache"
+		},
+		{
+			"label": "Docker Compose: Up",
+			"type": "shell",
+			"dependsOn": "Docker Compose: Build",
+			"command": "docker compose -f ${workspaceFolder}/compose.yml -f ${workspaceFolder}/compose.debug.yml up -d"
+		},
+		{
+			"label": "Docker Compose: Down",
+			"type": "shell",
+			"command": "docker compose -f ${workspaceFolder}/compose.yml -f ${workspaceFolder}/compose.debug.yml down",
+			"presentation": {
+				"reveal": "never"
+			}
+		}
+	]
 }

--- a/backend/Resumi/Api/Controllers/CertificatesController.cs
+++ b/backend/Resumi/Api/Controllers/CertificatesController.cs
@@ -1,8 +1,10 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Resumi.Api.Data.Models;
 using Resumi.App.Data.Models;
 using Resumi.App.Modules;
+using Resumi.App.Services.Validators;
 using Resumi.Infra.Auth;
 using Resumi.Infra.Database.Context;
 using Resumi.Infra.Data.Models;
@@ -10,82 +12,60 @@ using Resumi.Infra.Data.Models;
 namespace Resumi.Api.Controllers;
 
 [ApiController]
-[Route("api/resumes/{resumeId:int}/certificates")]
+[Route("api/certificates")]
 [Authorize]
-public class CertificatesController : ControllerBase
+public class CertificatesController(CertificatesModule module, AppDbContext dbContext, UserContext userContext)
+    : ControllerBase
 {
-    private readonly CertificatesModule _module;
-    private readonly AppDbContext _dbContext;
-    private readonly UserContext _userContext;
-
-    public CertificatesController(CertificatesModule module, AppDbContext dbContext, UserContext userContext)
-    {
-        _module = module;
-        _dbContext = dbContext;
-        _userContext = userContext;
-    }
-
     [HttpPost]
     [ProducesResponseType(typeof(Result<CertificateModel>), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(Result<CertificateModel>), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(Result<CertificateModel>), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> Create(int resumeId, [FromBody] AddCertificateModel model)
+    public async Task<IActionResult> Create([Required] int resumeId, [Required] [FromBody] AddCertificateModel model)
     {
-        if (model is null)
-            return BadRequest(Result<CertificateModel>.Failure("model", "Request body is required."));
-
         if (model.ResumeId != resumeId)
-            return BadRequest(Result<CertificateModel>.Failure("resumeId", "Resume ID in URL and body must match."));
-
-        var resume = await _dbContext.Resumes.FindAsync(resumeId);
-        if (resume is null)
-            return NotFound(Result<CertificateModel>.Failure("resumeId", "Resume not found."));
-
-        if (resume.UserId != _userContext.GetUserId())
-            return Forbid();
-
-        if (!Enum.TryParse<CertificateType>(model.Type, true, out var parsedType))
         {
-            return BadRequest(Result<CertificateModel>.Failure("type", "Tipo de certificado inválido."));
+            return BadRequest(Result<CertificateModel>.Failure(nameof(Resume),
+                $"Os campos {nameof(model.ResumeId)} e {nameof(resumeId)} devem ser iguais."));
         }
 
-        var certificate = new Certificate
-        {
-            ResumeId = model.ResumeId,
-            Name = model.Name,
-            Description = model.Description,
-            InstitutionName = model.InstitutionName,
-            Location = model.Location,
-            IsRemote = model.IsRemote,
-            StartDate = model.StartDate,
-            EndDate = model.EndDate,
-            StillEngaged = model.StillEngaged,
-            CredentialId = model.CredentialId,
-            CredentialUrl = model.CredentialUrl,
-            Type = parsedType,
-        };
+        var resume = await dbContext.Resumes.FindAsync(resumeId);
 
-        var creationResult = await _module.Service.CreateAsync(certificate);
+        if (resume is null)
+        {
+            return NotFound(Result<CertificateModel>.Failure(nameof(Resume), ResumeValidator.NotFound));
+        }
+
+        if (resume.UserId != userContext.GetUserId()) return Forbid();
+
+        var certificate = module.Mapper.NewDomainModel(model);
+
+        var creationResult = await module.Service.CreateAsync(certificate);
 
         if (!creationResult.Succeeded)
+        {
             return BadRequest(Result<CertificateModel>.Failure(creationResult.Errors));
+        }
 
-        var dto = ToDto(creationResult.Data!);
+        var certificateModel = module.Mapper.ToDto(creationResult.Data);
 
-        return CreatedAtAction(nameof(Read), new { resumeId, id = dto.Id }, Result<CertificateModel>.Success(dto));
+        if (certificateModel is null) return UnprocessableEntity();
+
+        return Created($"api/certificates/{certificateModel.Id}", Result<CertificateModel>.Success(certificateModel));
     }
 
     [HttpGet]
     [ProducesResponseType(typeof(Result<IEnumerable<CertificateModel>>), StatusCodes.Status200OK)]
     public async Task<IActionResult> ReadAll(int resumeId)
     {
-        var resume = await _dbContext.Resumes.FindAsync(resumeId);
+        var resume = await dbContext.Resumes.FindAsync(resumeId);
         if (resume is null)
             return NotFound(Result<IEnumerable<CertificateModel>>.Failure("resumeId", "Resume not found."));
 
-        if (resume.UserId != _userContext.GetUserId())
+        if (resume.UserId != userContext.GetUserId())
             return Forbid();
 
-        var certificates = _dbContext.Certificates.Where(c => c.ResumeId == resumeId).ToList();
+        var certificates = dbContext.Certificates.Where(c => c.ResumeId == resumeId).ToList();
         var list = certificates.Select(ToDto);
 
         return Ok(Result<IEnumerable<CertificateModel>>.Success(list));
@@ -95,14 +75,14 @@ public class CertificatesController : ControllerBase
     [ProducesResponseType(typeof(Result<CertificateModel>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Read(int resumeId, int id)
     {
-        var resume = await _dbContext.Resumes.FindAsync(resumeId);
+        var resume = await dbContext.Resumes.FindAsync(resumeId);
         if (resume is null)
             return NotFound(Result<CertificateModel>.Failure("resumeId", "Resume not found."));
 
-        if (resume.UserId != _userContext.GetUserId())
+        if (resume.UserId != userContext.GetUserId())
             return Forbid();
 
-        var fetched = await _module.Service.FindAsync(id);
+        var fetched = await module.Service.FindAsync(id);
         if (!fetched.Succeeded || fetched.Data is null)
             return NotFound(Result<CertificateModel>.Failure("id", "Certificate not found."));
 
@@ -122,14 +102,14 @@ public class CertificatesController : ControllerBase
         if (id != model.Id)
             return BadRequest(Result<CertificateModel>.Failure("id", "ID in URL and body must match."));
 
-        var resume = await _dbContext.Resumes.FindAsync(resumeId);
+        var resume = await dbContext.Resumes.FindAsync(resumeId);
         if (resume is null)
             return NotFound(Result<CertificateModel>.Failure("resumeId", "Resume not found."));
 
-        if (resume.UserId != _userContext.GetUserId())
+        if (resume.UserId != userContext.GetUserId())
             return Forbid();
 
-        var currentResult = await _module.Service.FindAsync(id);
+        var currentResult = await module.Service.FindAsync(id);
         if (!currentResult.Succeeded || currentResult.Data is null)
             return NotFound(Result<CertificateModel>.Failure("id", "Certificate not found."));
 
@@ -156,7 +136,7 @@ public class CertificatesController : ControllerBase
             current.Type = parsedType;
         }
 
-        var updateResult = await _module.Service.UpdateAsync(current, current);
+        var updateResult = await module.Service.UpdateAsync(current, current);
         if (!updateResult.Succeeded || updateResult.Data is null)
             return BadRequest(Result<CertificateModel>.Failure(updateResult.Errors));
 
@@ -166,21 +146,21 @@ public class CertificatesController : ControllerBase
     [HttpDelete("{id:int}")]
     public async Task<IActionResult> Delete(int resumeId, int id)
     {
-        var resume = await _dbContext.Resumes.FindAsync(resumeId);
+        var resume = await dbContext.Resumes.FindAsync(resumeId);
         if (resume is null)
             return NotFound(Result<bool>.Failure("resumeId", "Resume not found."));
 
-        if (resume.UserId != _userContext.GetUserId())
+        if (resume.UserId != userContext.GetUserId())
             return Forbid();
 
-        var currentResult = await _module.Service.FindAsync(id);
+        var currentResult = await module.Service.FindAsync(id);
         if (!currentResult.Succeeded || currentResult.Data is null)
             return NotFound(Result<bool>.Failure("id", "Certificate not found."));
 
         if (currentResult.Data.ResumeId != resumeId)
             return NotFound(Result<bool>.Failure("id", "Certificate does not belong to this resume."));
 
-        var deleteResult = await _module.Service.DeleteAsync(id);
+        var deleteResult = await module.Service.DeleteAsync(id);
 
         if (!deleteResult.Succeeded)
             return BadRequest(Result<bool>.Failure("id", "Could not delete certificate."));

--- a/backend/Resumi/Api/Controllers/CertificatesController.cs
+++ b/backend/Resumi/Api/Controllers/CertificatesController.cs
@@ -1,0 +1,210 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Resumi.Api.Data.Models;
+using Resumi.App.Data.Models;
+using Resumi.App.Modules;
+using Resumi.Infra.Auth;
+using Resumi.Infra.Database.Context;
+using Resumi.Infra.Data.Models;
+
+namespace Resumi.Api.Controllers;
+
+[ApiController]
+[Route("api/resumes/{resumeId:int}/certificates")]
+[Authorize]
+public class CertificatesController : ControllerBase
+{
+    private readonly CertificatesModule _module;
+    private readonly AppDbContext _dbContext;
+    private readonly UserContext _userContext;
+
+    public CertificatesController(CertificatesModule module, AppDbContext dbContext, UserContext userContext)
+    {
+        _module = module;
+        _dbContext = dbContext;
+        _userContext = userContext;
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(Result<CertificateModel>), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(Result<CertificateModel>), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Create(int resumeId, [FromBody] AddCertificateModel model)
+    {
+        if (model is null)
+            return BadRequest(Result<CertificateModel>.Failure("model", "Request body is required."));
+
+        if (model.ResumeId != resumeId)
+            return BadRequest(Result<CertificateModel>.Failure("resumeId", "Resume ID in URL and body must match."));
+
+        var resume = await _dbContext.Resumes.FindAsync(resumeId);
+        if (resume is null)
+            return NotFound(Result<CertificateModel>.Failure("resumeId", "Resume not found."));
+
+        if (resume.UserId != _userContext.GetUserId())
+            return Forbid();
+
+        if (!Enum.TryParse<CertificateType>(model.Type, true, out var parsedType))
+        {
+            return BadRequest(Result<CertificateModel>.Failure("type", "Tipo de certificado inválido."));
+        }
+
+        var certificate = new Certificate
+        {
+            ResumeId = model.ResumeId,
+            Name = model.Name,
+            Description = model.Description,
+            InstitutionName = model.InstitutionName,
+            Location = model.Location,
+            IsRemote = model.IsRemote,
+            StartDate = model.StartDate,
+            EndDate = model.EndDate,
+            StillEngaged = model.StillEngaged,
+            CredentialId = model.CredentialId,
+            CredentialUrl = model.CredentialUrl,
+            Type = parsedType,
+        };
+
+        var creationResult = await _module.Service.CreateAsync(certificate);
+
+        if (!creationResult.Succeeded)
+            return BadRequest(Result<CertificateModel>.Failure(creationResult.Errors));
+
+        var dto = ToDto(creationResult.Data!);
+
+        return CreatedAtAction(nameof(Read), new { resumeId, id = dto.Id }, Result<CertificateModel>.Success(dto));
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(Result<IEnumerable<CertificateModel>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> ReadAll(int resumeId)
+    {
+        var resume = await _dbContext.Resumes.FindAsync(resumeId);
+        if (resume is null)
+            return NotFound(Result<IEnumerable<CertificateModel>>.Failure("resumeId", "Resume not found."));
+
+        if (resume.UserId != _userContext.GetUserId())
+            return Forbid();
+
+        var certificates = _dbContext.Certificates.Where(c => c.ResumeId == resumeId).ToList();
+        var list = certificates.Select(ToDto);
+
+        return Ok(Result<IEnumerable<CertificateModel>>.Success(list));
+    }
+
+    [HttpGet("{id:int}")]
+    [ProducesResponseType(typeof(Result<CertificateModel>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Read(int resumeId, int id)
+    {
+        var resume = await _dbContext.Resumes.FindAsync(resumeId);
+        if (resume is null)
+            return NotFound(Result<CertificateModel>.Failure("resumeId", "Resume not found."));
+
+        if (resume.UserId != _userContext.GetUserId())
+            return Forbid();
+
+        var fetched = await _module.Service.FindAsync(id);
+        if (!fetched.Succeeded || fetched.Data is null)
+            return NotFound(Result<CertificateModel>.Failure("id", "Certificate not found."));
+
+        if (fetched.Data.ResumeId != resumeId)
+            return NotFound(Result<CertificateModel>.Failure("id", "Certificate does not belong to this resume."));
+
+        return Ok(Result<CertificateModel>.Success(ToDto(fetched.Data)));
+    }
+
+    [HttpPut("{id:int}")]
+    [ProducesResponseType(typeof(Result<CertificateModel>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Update(int resumeId, int id, [FromBody] UpdateCertificateModel model)
+    {
+        if (model is null)
+            return BadRequest(Result<CertificateModel>.Failure("model", "Request body is required."));
+
+        if (id != model.Id)
+            return BadRequest(Result<CertificateModel>.Failure("id", "ID in URL and body must match."));
+
+        var resume = await _dbContext.Resumes.FindAsync(resumeId);
+        if (resume is null)
+            return NotFound(Result<CertificateModel>.Failure("resumeId", "Resume not found."));
+
+        if (resume.UserId != _userContext.GetUserId())
+            return Forbid();
+
+        var currentResult = await _module.Service.FindAsync(id);
+        if (!currentResult.Succeeded || currentResult.Data is null)
+            return NotFound(Result<CertificateModel>.Failure("id", "Certificate not found."));
+
+        if (currentResult.Data.ResumeId != resumeId)
+            return NotFound(Result<CertificateModel>.Failure("id", "Certificate does not belong to this resume."));
+
+        var current = currentResult.Data;
+
+        if (!string.IsNullOrEmpty(model.Name)) current.Name = model.Name;
+        if (!string.IsNullOrEmpty(model.Description)) current.Description = model.Description;
+        if (!string.IsNullOrEmpty(model.InstitutionName)) current.InstitutionName = model.InstitutionName;
+        if (model.Location != null) current.Location = model.Location;
+        if (model.IsRemote.HasValue) current.IsRemote = model.IsRemote.Value;
+        if (model.StartDate.HasValue) current.StartDate = model.StartDate.Value;
+        if (model.EndDate.HasValue) current.EndDate = model.EndDate;
+        if (model.StillEngaged.HasValue) current.StillEngaged = model.StillEngaged.Value;
+        if (model.CredentialId != null) current.CredentialId = model.CredentialId;
+        if (model.CredentialUrl != null) current.CredentialUrl = model.CredentialUrl;
+        if (model.Type != null)
+        {
+            if (!Enum.TryParse<CertificateType>(model.Type, true, out var parsedType))
+                return BadRequest(Result<CertificateModel>.Failure("type", "Tipo de certificado inválido."));
+
+            current.Type = parsedType;
+        }
+
+        var updateResult = await _module.Service.UpdateAsync(current, current);
+        if (!updateResult.Succeeded || updateResult.Data is null)
+            return BadRequest(Result<CertificateModel>.Failure(updateResult.Errors));
+
+        return Ok(Result<CertificateModel>.Success(ToDto(updateResult.Data)));
+    }
+
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> Delete(int resumeId, int id)
+    {
+        var resume = await _dbContext.Resumes.FindAsync(resumeId);
+        if (resume is null)
+            return NotFound(Result<bool>.Failure("resumeId", "Resume not found."));
+
+        if (resume.UserId != _userContext.GetUserId())
+            return Forbid();
+
+        var currentResult = await _module.Service.FindAsync(id);
+        if (!currentResult.Succeeded || currentResult.Data is null)
+            return NotFound(Result<bool>.Failure("id", "Certificate not found."));
+
+        if (currentResult.Data.ResumeId != resumeId)
+            return NotFound(Result<bool>.Failure("id", "Certificate does not belong to this resume."));
+
+        var deleteResult = await _module.Service.DeleteAsync(id);
+
+        if (!deleteResult.Succeeded)
+            return BadRequest(Result<bool>.Failure("id", "Could not delete certificate."));
+
+        return NoContent();
+    }
+
+    private static CertificateModel ToDto(Certificate certificate)
+    {
+        return new CertificateModel
+        {
+            Id = certificate.Id,
+            ResumeId = certificate.ResumeId,
+            Name = certificate.Name,
+            Description = certificate.Description,
+            InstitutionName = certificate.InstitutionName,
+            Location = certificate.Location,
+            IsRemote = certificate.IsRemote,
+            StartDate = certificate.StartDate,
+            EndDate = certificate.EndDate,
+            StillEngaged = certificate.StillEngaged,
+            CredentialId = certificate.CredentialId,
+            CredentialUrl = certificate.CredentialUrl,
+            Type = certificate.Type.ToString(),
+        };
+    }
+}

--- a/backend/Resumi/Api/Data/Models/AddCertificateModel.cs
+++ b/backend/Resumi/Api/Data/Models/AddCertificateModel.cs
@@ -6,5 +6,5 @@ public record AddCertificateModel : AddResumeNodeModel
 {
     public string? CredentialId { get; init; }
     public string? CredentialUrl { get; init; }
-    [Required] public string? Type { get; init; }
+    [Required] public required string Type { get; init; }
 }

--- a/backend/Resumi/Api/Data/Models/AddResumeNodeModel.cs
+++ b/backend/Resumi/Api/Data/Models/AddResumeNodeModel.cs
@@ -12,17 +12,17 @@ public abstract record AddResumeNodeModel
 {
     [Required] public int ResumeId { get; init; }
 
-    [Required] [StringLength(128)] public string? Name { get; init; }
+    [Required] [StringLength(128)] public required string Name { get; init; }
 
-    [Required] [StringLength(256)] public string? Description { get; init; }
+    [Required] [StringLength(256)] public required string Description { get; init; }
 
-    [Required] [StringLength(128)] public string? InstitutionName { get; init; }
+    [Required] [StringLength(128)] public required string InstitutionName { get; init; }
 
     [StringLength(64)] public string? Location { get; init; }
 
     [Required] public bool IsRemote { get; init; }
 
-    [Required] public DateTime StartDate { get; init; }
+    [Required] public required DateTime StartDate { get; init; }
     public DateTime? EndDate { get; init; }
 
     [Required] public bool StillEngaged { get; init; }

--- a/backend/Resumi/App/Data/Models/CertificateType.cs
+++ b/backend/Resumi/App/Data/Models/CertificateType.cs
@@ -21,7 +21,12 @@ public enum CertificateType
     Badge = 2,
 
     /// <summary>
+    /// Certificado relacionado a atividades extracurriculares, eventos, ou projetos voluntários.
+    /// </summary>
+    Extracurricular = 3,
+
+    /// <summary>
     /// Indicação ou nomeação por um prêmio ou reconhecimento.
     /// </summary>
-    Nomination = 3,
+    Nomination = 4,
 }

--- a/backend/Resumi/App/Modules/CertificatesModule.cs
+++ b/backend/Resumi/App/Modules/CertificatesModule.cs
@@ -1,19 +1,24 @@
 using Microsoft.AspNetCore.Identity;
 using Resumi.App.Data.Models;
 using Resumi.App.Services.Interfaces;
+using Resumi.Infra.Data.Interfaces;
 using Resumi.Infra.Database.Interfaces;
 
 namespace Resumi.App.Modules;
 
 public class CertificatesModule : DomainModule<Certificate>
 {
+    public readonly ICertificateMapper Mapper;
+
     public CertificatesModule(
         IDomainService<Certificate> service,
         IDomainValidator<Certificate> validator,
         UserManager<AppUser> userManager,
         RoleManager<IdentityRole<int>> roleManager,
+        ICertificateMapper mapper,
         IRepository<Certificate>? repository = null)
         : base(service, validator, userManager, roleManager, repository)
     {
+        Mapper = mapper;
     }
 }

--- a/backend/Resumi/App/Services/CertificateService.cs
+++ b/backend/Resumi/App/Services/CertificateService.cs
@@ -1,33 +1,101 @@
+using Microsoft.EntityFrameworkCore;
 using Resumi.App.Data.Models;
 using Resumi.App.Services.Interfaces;
 using Resumi.Infra.Data.Models;
+using Resumi.Infra.Database.Context;
+using Resumi.Infra.Database.Interfaces;
 
 namespace Resumi.App.Services;
 
 public class CertificateService : ICertificateService
 {
-    public Task<Result<Certificate>> CreateAsync(Certificate? newEntity)
+    private readonly IDomainValidator<Certificate> _validator;
+    private readonly IRepository<Certificate> _repository;
+    private readonly AppDbContext _dbContext;
+
+    public CertificateService(
+        IDomainValidator<Certificate> validator,
+        IRepository<Certificate> repository,
+        AppDbContext dbContext)
     {
-        throw new NotImplementedException();
+        _validator = validator;
+        _repository = repository;
+        _dbContext = dbContext;
     }
 
-    public Task<Result<Certificate>> FindAsync(int id)
+    public async Task<Result<Certificate>> CreateAsync(Certificate? newEntity)
     {
-        throw new NotImplementedException();
+        var validation = _validator.ValidateCreation(newEntity);
+        if (!validation.Succeeded)
+            return Result<Certificate>.Failure(validation.Errors);
+
+        var added = await _repository.AddAsync(newEntity!);
+        if (added is null)
+            return Result<Certificate>.Failure("Certificate", "Failed to add certificate.");
+
+        await _dbContext.CommitAsync();
+        return Result<Certificate>.Success(added);
     }
 
-    public Task<Result<IEnumerable<Certificate>>> FindAllAsync(int skip = 0, int take = 20)
+    public async Task<Result<Certificate>> FindAsync(int id)
     {
-        throw new NotImplementedException();
+        var certificate = await _repository.GetByIdAsync(id);
+        if (certificate is null)
+            return Result<Certificate>.Failure("id", "Certificate not found.");
+
+        return Result<Certificate>.Success(certificate);
     }
 
-    public Task<Result<Certificate>> UpdateAsync(Certificate? current, Certificate? updated)
+    public async Task<Result<IEnumerable<Certificate>>> FindAllAsync(int skip = 0, int take = 20)
     {
-        throw new NotImplementedException();
+        var certificates = await _dbContext.Certificates.AsNoTracking()
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync();
+
+        return Result<IEnumerable<Certificate>>.Success(certificates);
     }
 
-    public Task<Result<bool>> DeleteAsync(int id)
+    public async Task<Result<Certificate>> UpdateAsync(Certificate? current, Certificate? updated)
     {
-        throw new NotImplementedException();
+        if (current is null || updated is null)
+            return Result<Certificate>.Failure("certificate", "Invalid certificate data.");
+
+        var validation = _validator.ValidateUpdate(current, updated);
+        if (!validation.Succeeded)
+            return Result<Certificate>.Failure(validation.Errors);
+
+        current.Name = updated.Name ?? current.Name;
+        current.Description = updated.Description ?? current.Description;
+        current.InstitutionName = updated.InstitutionName ?? current.InstitutionName;
+        current.Location = updated.Location ?? current.Location;
+        current.IsRemote = updated.IsRemote;
+        current.StartDate = updated.StartDate;
+        current.EndDate = updated.EndDate;
+        current.StillEngaged = updated.StillEngaged;
+        current.CredentialId = updated.CredentialId ?? current.CredentialId;
+        current.CredentialUrl = updated.CredentialUrl ?? current.CredentialUrl;
+        current.Type = updated.Type;
+
+        var updatedEntity = await _repository.UpdateAsync(current);
+        if (updatedEntity is null)
+            return Result<Certificate>.Failure("certificate", "Failed to update certificate.");
+
+        await _dbContext.CommitAsync();
+        return Result<Certificate>.Success(updatedEntity);
+    }
+
+    public async Task<Result<bool>> DeleteAsync(int id)
+    {
+        var exists = await _repository.GetByIdAsync(id);
+        if (exists is null)
+            return Result<bool>.Failure("id", "Certificate not found.");
+
+        var deleted = await _repository.DeleteAsync(id);
+        if (!deleted)
+            return Result<bool>.Failure("id", "Could not delete certificate.");
+
+        await _dbContext.CommitAsync();
+        return Result<bool>.Success(true);
     }
 }

--- a/backend/Resumi/App/Services/Validators/CertificateValidator.cs
+++ b/backend/Resumi/App/Services/Validators/CertificateValidator.cs
@@ -6,69 +6,75 @@ namespace Resumi.App.Services.Validators;
 
 public class CertificateValidator : IDomainValidator<Certificate>
 {
-    public Result<Certificate> ValidateCreation(Certificate? newCertificate)
+    public static readonly string InvalidCreationModel = "O modelo de certificado fornecido é inválido.";
+    public static readonly string InvalidPeriodRange = "A data de término deve ser posterior à data de início.";
+
+    public static readonly string RequiredNotEngagedState =
+        "Se o usuário não está mais durante o processo de certificação, a data de término é obrigatória.";
+
+    public static readonly string NotFound = "Certificado não encontrado.";
+    public static readonly string InvalidUpdateModel = "O modelo de certificado para atualização é inválido.";
+
+    public Result<Certificate> ValidateCreation(Certificate? newEntity)
     {
-        if (newCertificate is null)
-            return Result<Certificate>.Failure("certificate", "Certificate is required.");
+        if (newEntity is null)
+        {
+            return Result<Certificate>.Failure(nameof(Certificate), InvalidCreationModel);
+        }
 
-        var errors = new ResultDictionary();
+        ResultDictionary errors = [];
 
-        if (newCertificate.ResumeId <= 0)
-            errors.AddError("resumeId", "Resume ID must be a positive integer.");
+        if (newEntity is { StillEngaged: false, EndDate: null })
+        {
+            errors.AddError(nameof(Certificate), RequiredNotEngagedState);
+        }
 
-        if (string.IsNullOrWhiteSpace(newCertificate.Name))
-            errors.AddError("name", "Name is required.");
+        if (newEntity.EndDate.HasValue && newEntity.EndDate < newEntity.StartDate)
+        {
+            errors.AddError(nameof(Certificate), InvalidPeriodRange);
+        }
 
-        if (string.IsNullOrWhiteSpace(newCertificate.Description))
-            errors.AddError("description", "Description is required.");
-
-        if (string.IsNullOrWhiteSpace(newCertificate.InstitutionName))
-            errors.AddError("institutionName", "Institution name is required.");
-
-        if (newCertificate.StartDate == default)
-            errors.AddError("startDate", "Start date is required.");
-
-        if (newCertificate.EndDate.HasValue && newCertificate.EndDate < newCertificate.StartDate)
-            errors.AddError("endDate", "End date cannot be before start date.");
-
-        if (errors.Any())
-            return Result<Certificate>.Failure(errors);
-
-        return Result<Certificate>.Success(newCertificate);
+        return errors.Any() ? Result<Certificate>.Failure(errors) : Result<Certificate>.Success(newEntity);
     }
 
-    public Result<Certificate> ValidateSearch(Certificate? targetCertificate)
+    public Result<Certificate> ValidateSearch(Certificate? targetEntity)
     {
-        if (targetCertificate is null || targetCertificate.Id <= 0)
-            return Result<Certificate>.Failure("id", "Certificate ID is required for search.");
-
-        return Result<Certificate>.Success(targetCertificate);
+        return targetEntity is null
+            ? Result<Certificate>.Failure(nameof(Certificate), NotFound)
+            : Result<Certificate>.Success(targetEntity);
     }
 
     public Result<Certificate> ValidateUpdate(Certificate? current, Certificate? updated)
     {
-        if (current is null || updated is null)
-            return Result<Certificate>.Failure("certificate", "Certificate update requires current and updated entities.");
+        if (current is null)
+        {
+            return Result<Certificate>.Failure(nameof(Certificate), NotFound);
+        }
 
-        var errors = new ResultDictionary();
+        if (updated is null)
+        {
+            return Result<Certificate>.Failure(nameof(Certificate), InvalidUpdateModel);
+        }
 
-        if (updated.StartDate == default)
-            errors.AddError("startDate", "Start date is required.");
+        ResultDictionary errors = [];
+
+        if (updated is { StillEngaged: false, EndDate: null })
+        {
+            errors.AddError(nameof(Certificate), RequiredNotEngagedState);
+        }
 
         if (updated.EndDate.HasValue && updated.EndDate < updated.StartDate)
-            errors.AddError("endDate", "End date cannot be before start date.");
+        {
+            errors.AddError(nameof(Certificate), InvalidPeriodRange);
+        }
 
-        if (errors.Any())
-            return Result<Certificate>.Failure(errors);
-
-        return Result<Certificate>.Success(updated);
+        return errors.Any() ? Result<Certificate>.Failure(errors) : Result<Certificate>.Success(updated);
     }
 
-    public Result<Certificate> ValidateDeletion(Certificate? targetCertificate)
+    public Result<Certificate> ValidateDeletion(Certificate? targetEntity)
     {
-        if (targetCertificate is null || targetCertificate.Id <= 0)
-            return Result<Certificate>.Failure("id", "Certificate id is required for deletion.");
-
-        return Result<Certificate>.Success(targetCertificate);
+        return targetEntity is null
+            ? Result<Certificate>.Failure(nameof(Certificate), NotFound)
+            : Result<Certificate>.Success(targetEntity);
     }
 }

--- a/backend/Resumi/App/Services/Validators/CertificateValidator.cs
+++ b/backend/Resumi/App/Services/Validators/CertificateValidator.cs
@@ -8,21 +8,67 @@ public class CertificateValidator : IDomainValidator<Certificate>
 {
     public Result<Certificate> ValidateCreation(Certificate? newCertificate)
     {
-        throw new NotImplementedException();
+        if (newCertificate is null)
+            return Result<Certificate>.Failure("certificate", "Certificate is required.");
+
+        var errors = new ResultDictionary();
+
+        if (newCertificate.ResumeId <= 0)
+            errors.AddError("resumeId", "Resume ID must be a positive integer.");
+
+        if (string.IsNullOrWhiteSpace(newCertificate.Name))
+            errors.AddError("name", "Name is required.");
+
+        if (string.IsNullOrWhiteSpace(newCertificate.Description))
+            errors.AddError("description", "Description is required.");
+
+        if (string.IsNullOrWhiteSpace(newCertificate.InstitutionName))
+            errors.AddError("institutionName", "Institution name is required.");
+
+        if (newCertificate.StartDate == default)
+            errors.AddError("startDate", "Start date is required.");
+
+        if (newCertificate.EndDate.HasValue && newCertificate.EndDate < newCertificate.StartDate)
+            errors.AddError("endDate", "End date cannot be before start date.");
+
+        if (errors.Any())
+            return Result<Certificate>.Failure(errors);
+
+        return Result<Certificate>.Success(newCertificate);
     }
 
     public Result<Certificate> ValidateSearch(Certificate? targetCertificate)
     {
-        throw new NotImplementedException();
+        if (targetCertificate is null || targetCertificate.Id <= 0)
+            return Result<Certificate>.Failure("id", "Certificate ID is required for search.");
+
+        return Result<Certificate>.Success(targetCertificate);
     }
 
     public Result<Certificate> ValidateUpdate(Certificate? current, Certificate? updated)
     {
-        throw new NotImplementedException();
+        if (current is null || updated is null)
+            return Result<Certificate>.Failure("certificate", "Certificate update requires current and updated entities.");
+
+        var errors = new ResultDictionary();
+
+        if (updated.StartDate == default)
+            errors.AddError("startDate", "Start date is required.");
+
+        if (updated.EndDate.HasValue && updated.EndDate < updated.StartDate)
+            errors.AddError("endDate", "End date cannot be before start date.");
+
+        if (errors.Any())
+            return Result<Certificate>.Failure(errors);
+
+        return Result<Certificate>.Success(updated);
     }
 
     public Result<Certificate> ValidateDeletion(Certificate? targetCertificate)
     {
-        throw new NotImplementedException();
+        if (targetCertificate is null || targetCertificate.Id <= 0)
+            return Result<Certificate>.Failure("id", "Certificate id is required for deletion.");
+
+        return Result<Certificate>.Success(targetCertificate);
     }
 }

--- a/backend/Resumi/App/Services/Validators/ResumeValidator.cs
+++ b/backend/Resumi/App/Services/Validators/ResumeValidator.cs
@@ -8,6 +8,8 @@ public class ResumeValidator : IDomainValidator<Resume>
 {
     private const int MaxTitleLength = 128;
 
+    public static readonly string NotFound = "Currículo não encontrado.";
+
     public Result<Resume> ValidateCreation(Resume? newResume)
     {
         ResultDictionary errors = [];
@@ -19,7 +21,8 @@ public class ResumeValidator : IDomainValidator<Resume>
 
         if (newResume is not null && newResume.Title.Length > MaxTitleLength)
         {
-            errors.AddError(nameof(Resume.Title), $"O título do currículo não pode exceder {MaxTitleLength} caracteres.");
+            errors.AddError(nameof(Resume.Title),
+                $"O título do currículo não pode exceder {MaxTitleLength} caracteres.");
         }
 
         return errors.Count > 0

--- a/backend/Resumi/Infra/Data/Interfaces/ICertificateMapper.cs
+++ b/backend/Resumi/Infra/Data/Interfaces/ICertificateMapper.cs
@@ -1,0 +1,7 @@
+using Resumi.Api.Data.Models;
+using Resumi.App.Data.Models;
+
+namespace Resumi.Infra.Data.Interfaces;
+
+public interface
+    ICertificateMapper : IEntityMapper<Certificate, CertificateModel, AddCertificateModel, UpdateCertificateModel>;

--- a/backend/Resumi/Infra/Data/Mappers/CertificateMapper.cs
+++ b/backend/Resumi/Infra/Data/Mappers/CertificateMapper.cs
@@ -81,7 +81,54 @@ public class CertificateMapper(ILogger<CertificateMapper> logger) : ICertificate
 
 	public Certificate? UpdatedDomainModel(UpdateCertificateModel? dtoUpdate, Certificate? entity)
 	{
-		throw new NotImplementedException();
+		if (dtoUpdate is null || entity is null) return null;
+
+		try
+		{
+			if (dtoUpdate.Id != entity.Id)
+				throw new DomainException(
+					$"The ID of the update model ({dtoUpdate.Id}) does not match the ID of the entity ({entity.Id})."
+				);
+
+			var hasParsedType = CertificateTypeExtensions.FromDisplayString(dtoUpdate.Type, out var parsedType);
+
+			return new Certificate
+			{
+				#region Non-exposed properties
+
+				ResumeId = entity.ResumeId,
+				CreatedAt = entity.CreatedAt,
+				UpdatedAt = entity.UpdatedAt,
+
+				#endregion
+
+				Name = dtoUpdate.Name,
+				Description = dtoUpdate.Description,
+				InstitutionName = dtoUpdate.InstitutionName,
+				Location = dtoUpdate.Location,
+				IsRemote = dtoUpdate.IsRemote ?? entity.IsRemote,
+				StartDate = dtoUpdate.StartDate ?? entity.StartDate,
+				StillEngaged = dtoUpdate.StillEngaged ?? entity.StillEngaged,
+				EndDate = dtoUpdate.EndDate ?? entity.EndDate,
+				CredentialId = dtoUpdate.CredentialId ?? entity.CredentialId,
+				CredentialUrl = dtoUpdate.CredentialUrl ?? entity.CredentialUrl,
+				Type = dtoUpdate.Type is not null
+					? hasParsedType
+						? parsedType!.Value
+						: throw new DomainException($"Invalid certificate type: {dtoUpdate.Type}")
+					: entity.Type
+			};
+		}
+		catch (DomainException dex)
+		{
+			logger.LogError(
+				dex,
+				"Domain exception occurred while creating a new Certificate domain model: {Message}",
+				dex.Message
+			);
+
+			return null;
+		}
 	}
 }
 
@@ -102,9 +149,9 @@ static class CertificateTypeExtensions
 		return displayString != null;
 	}
 
-	public static bool FromDisplayString(string displayString, out CertificateType? type)
+	public static bool FromDisplayString(string? displayString, out CertificateType? type)
 	{
-		type = displayString.ToLower() switch
+		type = displayString?.ToLower() switch
 		{
 			"course" => CertificateType.Course,
 			"license" => CertificateType.License,

--- a/backend/Resumi/Infra/Data/Mappers/CertificateMapper.cs
+++ b/backend/Resumi/Infra/Data/Mappers/CertificateMapper.cs
@@ -1,0 +1,86 @@
+using Resumi.Api.Data.Models;
+using Resumi.App.Data.Models;
+using Resumi.App.Exceptions;
+using Resumi.Infra.Data.Interfaces;
+
+namespace Resumi.Infra.Data.Mappers;
+
+public class CertificateMapper(ILogger<CertificateMapper> logger) : ICertificateMapper
+{
+	public Certificate? NewDomainModel(AddCertificateModel dtoCreate)
+	{
+		try
+		{
+			return new Certificate
+			{
+				ResumeId = dtoCreate.ResumeId,
+				Name = dtoCreate.Name,
+				Description = dtoCreate.Description,
+				InstitutionName = dtoCreate.InstitutionName,
+				Location = dtoCreate.Location,
+				IsRemote = dtoCreate.IsRemote,
+				StartDate = dtoCreate.StartDate,
+				StillEngaged = dtoCreate.StillEngaged,
+				EndDate = dtoCreate.EndDate,
+				CredentialId = dtoCreate.CredentialId,
+				CredentialUrl = dtoCreate.CredentialUrl,
+				Type = CertificateTypeExtensions.FromDisplayString(dtoCreate.Type, out var parsedType)
+					? parsedType!.Value
+					: throw new DomainException($"Invalid certificate type: {dtoCreate.Type}")
+			};
+		}
+		catch (DomainException dex)
+		{
+			logger.LogError(
+				dex,
+				"Domain exception occurred while creating a new Certificate domain model: {Message}",
+				dex.Message
+			);
+
+			return null;
+		}
+	}
+
+	public CertificateModel? ToDto(Certificate? entity)
+	{
+		throw new NotImplementedException();
+	}
+
+	public Certificate? UpdatedDomainModel(UpdateCertificateModel? dtoUpdate, Certificate? entity)
+	{
+		throw new NotImplementedException();
+	}
+}
+
+static class CertificateTypeExtensions
+{
+	public static bool ToDisplayString(this CertificateType type, out string? displayString)
+	{
+		displayString = type switch
+		{
+			CertificateType.Course => "course",
+			CertificateType.License => "license",
+			CertificateType.Badge => "badge",
+			CertificateType.Extracurricular => "extracurricular",
+			CertificateType.Nomination => "nomination",
+			_ => null
+		};
+
+		return displayString != null;
+	}
+
+	public static bool FromDisplayString(string displayString, out CertificateType? type)
+	{
+		type = displayString.ToLower() switch
+		{
+			"course" => CertificateType.Course,
+			"license" => CertificateType.License,
+			"badge" => CertificateType.Badge,
+			"extracurricular" => CertificateType.Extracurricular,
+			"nomination" => CertificateType.Nomination,
+			_ => null
+		};
+
+		return type != null;
+	}
+}

--- a/backend/Resumi/Infra/Data/Mappers/CertificateMapper.cs
+++ b/backend/Resumi/Infra/Data/Mappers/CertificateMapper.cs
@@ -2,6 +2,7 @@ using Resumi.Api.Data.Models;
 using Resumi.App.Data.Models;
 using Resumi.App.Exceptions;
 using Resumi.Infra.Data.Interfaces;
+using Resumi.Infra.Exceptions;
 
 namespace Resumi.Infra.Data.Mappers;
 
@@ -43,7 +44,39 @@ public class CertificateMapper(ILogger<CertificateMapper> logger) : ICertificate
 
 	public CertificateModel? ToDto(Certificate? entity)
 	{
-		throw new NotImplementedException();
+		try
+		{
+			if (entity is null) return null;
+
+			return new CertificateModel
+			{
+				Id = entity.Id,
+				ResumeId = entity.ResumeId,
+				Name = entity.Name,
+				Description = entity.Description,
+				InstitutionName = entity.InstitutionName,
+				Location = entity.Location,
+				IsRemote = entity.IsRemote,
+				StartDate = entity.StartDate,
+				EndDate = entity.EndDate,
+				StillEngaged = entity.StillEngaged,
+				CredentialId = entity.CredentialId,
+				CredentialUrl = entity.CredentialUrl,
+				Type = entity.Type.ToDisplayString(out var displayString)
+					? displayString!
+					: throw new InfrastructureException($"Certificate type not mapped: {entity.Type}"),
+			};
+		}
+		catch (InfrastructureException iex)
+		{
+			logger.LogError(
+				iex,
+				"Infrastructure exception occurred while mapping Certificate domain model to DTO: {Message}",
+				iex.Message
+			);
+
+			return null;
+		}
 	}
 
 	public Certificate? UpdatedDomainModel(UpdateCertificateModel? dtoUpdate, Certificate? entity)

--- a/backend/Resumi/Infra/Extensions/StartupExtensions.cs
+++ b/backend/Resumi/Infra/Extensions/StartupExtensions.cs
@@ -77,6 +77,7 @@ public static class StartupExtensions
     {
         services.AddScoped<IResumeMapper, ResumeMapper>();
         services.AddScoped<IUserMapper, UserMapper>();
+        services.AddScoped<ICertificateMapper, CertificateMapper>();
     }
 
 

--- a/backend/Resumi/Program.cs
+++ b/backend/Resumi/Program.cs
@@ -91,3 +91,6 @@ app.UseHsts();
 app.UseHttpsRedirection();
 app.MapControllers();
 app.Run();
+
+public partial class Program { }
+

--- a/backend/TestResumi/App/Controllers/TestCertificatesController.cs
+++ b/backend/TestResumi/App/Controllers/TestCertificatesController.cs
@@ -1,0 +1,117 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.InMemory;
+using Moq;
+using Resumi.Api.Controllers;
+using Resumi.Infra.Auth.Constants;
+using Resumi.Api.Data.Models;
+using Resumi.App.Data.Models;
+using Resumi.App.Modules;
+using Resumi.App.Services.Interfaces;
+using Resumi.Infra.Auth;
+using Resumi.Infra.Database.Context;
+using Resumi.Infra.Database.Interfaces;
+
+namespace TestResumi.App.Controllers;
+
+public class TestCertificatesController
+{
+    [Fact]
+    public async Task Create_ShouldReturnForbid_WhenResumeBelongsToAnotherUser()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: "CertificatesControllerForbid")
+            .Options;
+
+        await using var dbContext = new AppDbContext(options);
+        dbContext.Resumes.Add(new Resume { Id = 1, UserId = 1, Title = "Curriculo teste", Email = "a@b.com", PhoneNumber = "123", OwnerName = "Fulano" });
+        await dbContext.SaveChangesAsync();
+
+        var userManagerMock = new Mock<UserManager<AppUser>>(
+            Mock.Of<IUserStore<AppUser>>(), null, null, null, null, null, null, null, null);
+        var roleManagerMock = new Mock<RoleManager<IdentityRole<int>>>(
+            Mock.Of<IRoleStore<IdentityRole<int>>>(), null, null, null, null);
+
+        var serviceMock = new Mock<IDomainService<Certificate>>();
+        var validatorMock = new Mock<IDomainValidator<Certificate>>();
+        var repoMock = new Mock<IRepository<Certificate>>();
+
+        var module = new CertificatesModule(serviceMock.Object, validatorMock.Object, userManagerMock.Object, roleManagerMock.Object, repoMock.Object);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim(SessionConstants.UserIdClaim, "2"),
+        }, "Test"));
+        var userContext = new UserContext(new HttpContextAccessor { HttpContext = httpContext });
+
+        var controller = new CertificatesController(module, dbContext, userContext);
+
+        controller.ControllerContext.HttpContext = httpContext;
+
+        var request = new AddCertificateModel
+        {
+            ResumeId = 1,
+            Name = "Certificado",
+            Description = "Desc",
+            InstitutionName = "Instituição",
+            IsRemote = false,
+            StartDate = DateTime.UtcNow,
+            StillEngaged = false,
+            Type = "Extracurricular"
+        };
+
+        var result = await controller.Create(1, request);
+        Assert.IsType<Microsoft.AspNetCore.Mvc.ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task Create_ShouldReturnBadRequest_WhenResumeIdMismatch()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: "CertificatesControllerBadRequest")
+            .Options;
+
+        await using var dbContext = new AppDbContext(options);
+        dbContext.Resumes.Add(new Resume { Id = 2, UserId = 1, Title = "Curriculo", Email = "a@b.com", PhoneNumber = "123", OwnerName = "Fulano" });
+        await dbContext.SaveChangesAsync();
+
+        var userManagerMock = new Mock<UserManager<AppUser>>(
+            Mock.Of<IUserStore<AppUser>>(), null, null, null, null, null, null, null, null);
+        var roleManagerMock = new Mock<RoleManager<IdentityRole<int>>>(
+            Mock.Of<IRoleStore<IdentityRole<int>>>(), null, null, null, null);
+
+        var serviceMock = new Mock<IDomainService<Certificate>>();
+        var validatorMock = new Mock<IDomainValidator<Certificate>>();
+        var repoMock = new Mock<IRepository<Certificate>>();
+
+        var module = new CertificatesModule(serviceMock.Object, validatorMock.Object, userManagerMock.Object, roleManagerMock.Object, repoMock.Object);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim(SessionConstants.UserIdClaim, "1"),
+        }, "Test"));
+        var userContext = new UserContext(new HttpContextAccessor { HttpContext = httpContext });
+
+        var controller = new CertificatesController(module, dbContext, userContext);
+        controller.ControllerContext.HttpContext = httpContext;
+
+        var request = new AddCertificateModel
+        {
+            ResumeId = 9,
+            Name = "Certificado",
+            Description = "Desc",
+            InstitutionName = "Instituição",
+            IsRemote = false,
+            StartDate = DateTime.UtcNow,
+            StillEngaged = false,
+            Type = "Extracurricular"
+        };
+
+        var result = await controller.Create(2, request);
+        Assert.IsType<Microsoft.AspNetCore.Mvc.BadRequestObjectResult>(result);
+    }
+}

--- a/backend/TestResumi/App/Services/Validators/TestCertificateValidator.cs
+++ b/backend/TestResumi/App/Services/Validators/TestCertificateValidator.cs
@@ -1,0 +1,58 @@
+using Resumi.App.Data.Models;
+using Resumi.App.Services.Validators;
+
+namespace TestResumi.App.Services.Validators;
+
+public class TestCertificateValidator
+{
+    [Fact]
+    public void CreationShouldFailWhenRequiredFieldsMissing()
+    {
+        var validator = new CertificateValidator();
+        var result = validator.ValidateCreation(null);
+
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public void CreationShouldFailWhenStartDateIsDefault()
+    {
+        var certificate = new Certificate
+        {
+            ResumeId = 1,
+            Name = "Certificado teste",
+            Description = "Descrição teste",
+            InstitutionName = "Instituição",
+            IsRemote = false,
+            StartDate = default,
+            StillEngaged = false,
+            Type = CertificateType.Extracurricular,
+        };
+
+        var validator = new CertificateValidator();
+        var result = validator.ValidateCreation(certificate);
+
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public void CreationShouldSucceedWithValidData()
+    {
+        var certificate = new Certificate
+        {
+            ResumeId = 1,
+            Name = "Certificado teste",
+            Description = "Descrição teste",
+            InstitutionName = "Instituição",
+            IsRemote = false,
+            StartDate = DateTime.UtcNow,
+            StillEngaged = true,
+            Type = CertificateType.Extracurricular,
+        };
+
+        var validator = new CertificateValidator();
+        var result = validator.ValidateCreation(certificate);
+
+        Assert.True(result.Succeeded);
+    }
+}

--- a/backend/TestResumi/TestResumi.csproj
+++ b/backend/TestResumi/TestResumi.csproj
@@ -12,6 +12,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageReference Include="Moq" Version="4.20.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/compose.debug.yml
+++ b/compose.debug.yml
@@ -1,0 +1,16 @@
+services:
+  backend:
+    build:
+      labels:
+        - environment=development
+      args:
+        - configuration=Debug
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - WAIT_FOR_DEBUGGER=1
+    entrypoint:
+      - "/vsdbg/vsdbg"
+      - "--interpreter=vscode"
+      - "--pauseEngineForDebugger"
+    volumes:
+      - ${HOME}/vsdbg:/vsdbg:ro

--- a/compose.yml
+++ b/compose.yml
@@ -6,10 +6,11 @@ services:
       dockerfile: Dockerfile
       labels:
         - org.osderivados=resumi
+        - environment=production
       args:
-        - configuration=Debug
+        - configuration=Release
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_ENVIRONMENT=Production
       # Tell ASP.NET where the cert is and its password
       - ASPNETCORE_Kestrel__Certificates__Default__Path=/https/aspnet-dev-cert.pfx
       - ASPNETCORE_Kestrel__Certificates__Default__Password=${CERT_PASSWORD}
@@ -22,7 +23,6 @@ services:
       - "8081:8081" # HTTPS
     volumes:
       - ~/.aspnet/https/aspnet-dev-cert.pfx:/https/aspnet-dev-cert.pfx:ro
-      - ~/vsdbg:/vsdbg:ro
     depends_on:
       db:
         condition: service_healthy

--- a/frontend/resumi-frontend/app/data/api/add-certificate-model.ts
+++ b/frontend/resumi-frontend/app/data/api/add-certificate-model.ts
@@ -1,0 +1,14 @@
+export type AddCertificateModel = {
+  resumeId: number
+  name: string
+  description: string
+  institutionName: string
+  location?: string
+  isRemote: boolean
+  startDate: string
+  endDate?: string
+  stillEngaged: boolean
+  credentialId?: string
+  credentialUrl?: string
+  type: string
+}

--- a/frontend/resumi-frontend/app/data/api/read-certificate-model.ts
+++ b/frontend/resumi-frontend/app/data/api/read-certificate-model.ts
@@ -1,0 +1,15 @@
+export type ReadCertificateModel = {
+  id: number
+  resumeId: number
+  name: string
+  description: string
+  institutionName: string
+  location?: string
+  isRemote: boolean
+  startDate: string
+  endDate?: string
+  stillEngaged: boolean
+  credentialId?: string
+  credentialUrl?: string
+  type: string
+}

--- a/frontend/resumi-frontend/app/data/api/update-certificate-model.ts
+++ b/frontend/resumi-frontend/app/data/api/update-certificate-model.ts
@@ -1,0 +1,14 @@
+export type UpdateCertificateModel = {
+  id: number
+  name?: string
+  description?: string
+  institutionName?: string
+  location?: string
+  isRemote?: boolean
+  startDate?: string
+  endDate?: string
+  stillEngaged?: boolean
+  credentialId?: string
+  credentialUrl?: string
+  type?: string
+}

--- a/frontend/resumi-frontend/app/infra/api/certificate-service.ts
+++ b/frontend/resumi-frontend/app/infra/api/certificate-service.ts
@@ -1,0 +1,97 @@
+import type { AddCertificateModel } from "~/data/api/add-certificate-model";
+import type { ReadCertificateModel } from "~/data/api/read-certificate-model";
+import type { Result } from "~/infra/result";
+import { getEnvironmentVariable } from "~/infra/utils/environment-utils";
+import { BackendUrl } from "./api.constants";
+
+export async function getCertificatesAsync(resumeId: number): Promise<Result<ReadCertificateModel[]>> {
+  try {
+    const backendUrl = getEnvironmentVariable(BackendUrl);
+
+    if (!backendUrl) throw new Error("Backend URL is not defined.");
+
+    const result = await useFetch(`${backendUrl}/resumes/${resumeId}/certificates`, {
+      method: "GET",
+      credentials: "include",
+    });
+
+    return result.data.value as Result<ReadCertificateModel[]>;
+  } catch {
+    return {
+      succeeded: false,
+      errors: new Map<string, string[]>([["unknown", ["Erro ao buscar certificados."]]]),
+      allErrors: ["Erro ao buscar certificados."],
+    };
+  }
+}
+
+export async function createCertificateAsync(resumeId: number, model: AddCertificateModel): Promise<Result<ReadCertificateModel>> {
+  try {
+    const backendUrl = getEnvironmentVariable(BackendUrl);
+
+    if (!backendUrl) throw new Error("Backend URL is not defined.");
+
+    const result = await useFetch(`${backendUrl}/resumes/${resumeId}/certificates`, {
+      method: "POST",
+      credentials: "include",
+      body: JSON.stringify(model),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    return result.data.value as Result<ReadCertificateModel>;
+  } catch {
+    return {
+      succeeded: false,
+      errors: new Map<string, string[]>([["unknown", ["Erro ao criar certificado."]]]),
+      allErrors: ["Erro ao criar certificado."],
+    };
+  }
+}
+
+export async function updateCertificateAsync(resumeId: number, id: number, model: unknown): Promise<Result<ReadCertificateModel>> {
+  try {
+    const backendUrl = getEnvironmentVariable(BackendUrl);
+
+    if (!backendUrl) throw new Error("Backend URL is not defined.");
+
+    const result = await useFetch(`${backendUrl}/resumes/${resumeId}/certificates/${id}`, {
+      method: "PUT",
+      credentials: "include",
+      body: JSON.stringify(model),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    return result.data.value as Result<ReadCertificateModel>;
+  } catch {
+    return {
+      succeeded: false,
+      errors: new Map<string, string[]>([["unknown", ["Erro ao atualizar certificado."]]]),
+      allErrors: ["Erro ao atualizar certificado."],
+    };
+  }
+}
+
+export async function deleteCertificateAsync(resumeId: number, id: number): Promise<Result<null>> {
+  try {
+    const backendUrl = getEnvironmentVariable(BackendUrl);
+
+    if (!backendUrl) throw new Error("Backend URL is not defined.");
+
+    const result = await useFetch(`${backendUrl}/resumes/${resumeId}/certificates/${id}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+
+    return result.data.value as Result<null>;
+  } catch {
+    return {
+      succeeded: false,
+      errors: new Map<string, string[]>([["unknown", ["Erro ao excluir certificado."]]]),
+      allErrors: ["Erro ao excluir certificado."],
+    };
+  }
+}

--- a/frontend/resumi-frontend/app/views/components/resume-form.vue
+++ b/frontend/resumi-frontend/app/views/components/resume-form.vue
@@ -1,78 +1,263 @@
 <template>
-	<UForm class="w-full shadow py-8 px-16 my-16" :schema="vm.schema" :state="vm.state"
-		@submit="(e) => e.preventDefault()">
+	<UForm class="w-full shadow py-8 px-16 my-16" :schema="vm.schema" :state="vm.state" @submit="(e) => e.preventDefault()">
 		<UFormField label="Título" name="ownerName" class="w-full">
-			<UInput v-model="vm.state.ownerName" :variant="vm.getVariant('ownerName')"
-				@focus="vm.setFocus('ownerName', true)" @blur="vm.setFocus('ownerName', false)" class="w-full" :ui="{
-					base: 'text-2xl font-bold mb-4',
-				}" />
+			<UInput v-model="vm.state.ownerName" :variant="vm.getVariant('ownerName')" @focus="vm.setFocus('ownerName', true)" @blur="vm.setFocus('ownerName', false)" class="w-full" :ui="{ base: 'text-2xl font-bold mb-4' }" />
 		</UFormField>
 
 		<ul class="flex gap-8 my-4">
 			<li>
 				<UFormField label="E-mail" name="email" class="w-full">
-					<UInput v-model="vm.state.email" :variant="vm.getVariant('email')"
-						@focus="vm.setFocus('email', true)" @blur="vm.setFocus('email', false)" class="w-full" />
+					<UInput v-model="vm.state.email" :variant="vm.getVariant('email')" @focus="vm.setFocus('email', true)" @blur="vm.setFocus('email', false)" class="w-full" />
 				</UFormField>
 			</li>
-
 			<li>
 				<UFormField label="Cidade" name="location" class="w-full">
-					<UInput v-model="vm.state.location" :variant="vm.getVariant('location')"
-						@focus="vm.setFocus('location', true)" @blur="vm.setFocus('location', false)" class="w-full" />
+					<UInput v-model="vm.state.location" :variant="vm.getVariant('location')" @focus="vm.setFocus('location', true)" @blur="vm.setFocus('location', false)" class="w-full" />
 				</UFormField>
 			</li>
-
 			<li>
 				<UFormField label="Telefone" name="phoneNumber" class="w-full">
-					<UInput v-model="vm.state.phoneNumber" :variant="vm.getVariant('phoneNumber')"
-						@focus="vm.setFocus('phoneNumber', true)" @blur="vm.setFocus('phoneNumber', false)"
-						class="w-full" />
+					<UInput v-model="vm.state.phoneNumber" :variant="vm.getVariant('phoneNumber')" @focus="vm.setFocus('phoneNumber', true)" @blur="vm.setFocus('phoneNumber', false)" class="w-full" />
 				</UFormField>
 			</li>
 		</ul>
 
 		<UFormField label="Sobre Mim" name="description" class="w-full mb-4">
-			<UInput v-model="vm.state.description" :variant="vm.getVariant('description')"
-				@focus="vm.setFocus('description', true)" @blur="vm.setFocus('description', false)" class="w-full" />
+			<UInput v-model="vm.state.description" :variant="vm.getVariant('description')" @focus="vm.setFocus('description', true)" @blur="vm.setFocus('description', false)" class="w-full" />
 		</UFormField>
 
 		<UFormField label="Palavras-chave" name="keyword" class="w-full">
-			<UInput v-model="vm.state.keyword" :variant="vm.getVariant('keyword')" @focus="vm.setFocus('keyword', true)"
-				@blur="vm.setFocus('keyword', false)" class="w-full" />
+			<UInput v-model="vm.state.keyword" :variant="vm.getVariant('keyword')" @focus="vm.setFocus('keyword', true)" @blur="vm.setFocus('keyword', false)" class="w-full" />
 		</UFormField>
 
 		<article class="my-8">
 			<h2 class="text-lg font-semibold">Experiências</h2>
-
 			<p>Nenhuma experiência adicionada.</p>
-
 			<UButton label="Adicionar experiência" icon="i-lucide-plus" class="mt-4" />
 		</article>
 
 		<article class="my-8">
 			<h2 class="text-lg font-semibold">Formação Acadêmica</h2>
-
 			<p>Nenhuma formação acadêmica adicionada.</p>
-
 			<UButton label="Adicionar formação acadêmica" icon="i-lucide-plus" class="mt-4" />
 		</article>
 
-		<article class="my-8">
-			<h2 class="text-lg font-semibold">Atividades Extracurriculares</h2>
+	<article class="my-8">
+		<h2 class="text-lg font-semibold">Certificados</h2>
+		<div class="flex flex-wrap items-center gap-2 mt-2">
+			<UInput v-model="certificateFilter" placeholder="Filtrar por tipo, nome ou instituição" class="w-full md:w-96" />
+			<UButton label="Novo certificado" icon="i-lucide-plus" color="primary" size="sm" @click="openCreation = !openCreation" />
+		</div>
 
-			<p>Nenhuma atividade extracurricular adicionada.</p>
+		<div v-if="loadingCertificates" class="text-sm text-slate-500 mt-2">Carregando certificados...</div>
+		<ul v-else class="mt-2 space-y-2">
+			<li v-if="!filteredCertificates.length" class="text-sm text-slate-500">Nenhum certificado encontrado.</li>
+			<li v-for="certificate in filteredCertificates" :key="certificate.id" class="border p-3 rounded-lg">
+				<div class="flex justify-between gap-2 items-start">
+					<div>
+						<p class="font-semibold">{{ certificate.name }}</p>
+						<p class="text-xs text-slate-500">{{ certificate.type }} • {{ certificate.institutionName }}</p>
+						<p class="text-xs text-slate-500">{{ certificate.startDate }} - {{ certificate.endDate ?? 'Presente' }}</p>
+						<p class="text-xs text-slate-500" v-if="certificate.credentialUrl">Link: <a class="text-blue-600" :href="certificate.credentialUrl" target="_blank">Ver credencial</a></p>
+					</div>
+					<div class="flex gap-2">
+						<UButton label="Editar" size="sm" color="secondary" @click="startEdit(certificate)" />
+						<UButton label="Excluir" size="sm" color="danger" @click="removeCertificate(certificate.id)" />
+					</div>
+				</div>
+			</li>
+		</ul>
 
-			<UButton label="Adicionar atividade extracurricular" icon="i-lucide-plus" class="mt-4" />
-		</article>
+		<div v-if="openCreation" class="mt-3 border rounded-lg p-3 bg-slate-50">
+			<h3 class="font-semibold mb-2">{{ editingCertificate ? 'Editar certificado' : 'Novo certificado' }}</h3>
+			<div class="grid grid-cols-1 md:grid-cols-2 gap-2">
+				<UInput v-model="formCertificate.name" placeholder="Nome" />
+				<UInput v-model="formCertificate.institutionName" placeholder="Instituição" />
+				<UInput v-model="formCertificate.description" placeholder="Descrição" />
+				<UInput v-model="formCertificate.location" placeholder="Localização (opcional)" />
+				<UInput v-model="formCertificate.startDate" type="date" placeholder="Data início" />
+				<UInput v-model="formCertificate.endDate" type="date" placeholder="Data término" />
+				<USelect v-model="formCertificate.type" :options="certificateTypeOptions" />
+				<UInput v-model="formCertificate.credentialUrl" placeholder="URL do certificado (opcional)" />
+			</div>
+			<div class="flex gap-2 mt-3">
+				<UButton label="Salvar" color="primary" @click="submitCertificate" />
+				<UButton label="Cancelar" color="secondary" @click="closeForm" />
+			</div>
+			<div v-if="formErrors.length" class="mt-2 text-small text-red-600">
+				<ul>
+					<li v-for="error in formErrors" :key="error">{{ error }}</li>
+				</ul>
+			</div>
+		</div>
+	</article>
 	</UForm>
 </template>
 
 <script setup lang="ts">
+import { ref, reactive, computed, onMounted } from 'vue';
 import { ResumeFormViewModel } from '../models/resume-form.vm';
+import { getCertificatesAsync, createCertificateAsync, updateCertificateAsync, deleteCertificateAsync } from '~/infra/api/certificate-service';
+import type { ReadCertificateModel } from '~/data/api/read-certificate-model';
+import type { AddCertificateModel } from '~/data/api/add-certificate-model';
+import type { UpdateCertificateModel } from '~/data/api/update-certificate-model';
 
-const route = useRoute()
-const resumeId = Number(route.query.id)
+const route = useRoute();
+const resumeId = Number(route.query.id) || 0;
+const vm = new ResumeFormViewModel(resumeId);
 
-const vm = new ResumeFormViewModel(resumeId)
+const certificates = ref<ReadCertificateModel[]>([]);
+const loadingCertificates = ref(false);
+const openCreation = ref(false);
+const editingCertificate = ref<ReadCertificateModel | null>(null);
+const certificateFilter = ref('');
+const formErrors = ref<string[]>([]);
+
+const certificateTypeOptions = [
+	{ label: 'Extracurricular', value: 'Extracurricular' },
+	{ label: 'Curso', value: 'Course' },
+	{ label: 'Licença', value: 'License' },
+	{ label: 'Badge', value: 'Badge' },
+	{ label: 'Nomeação', value: 'Nomination' },
+];
+
+const formCertificate = reactive<Partial<AddCertificateModel & UpdateCertificateModel>>({
+	name: '',
+	description: '',
+	institutionName: '',
+	location: '',
+	isRemote: false,
+	startDate: new Date().toISOString().slice(0, 10),
+	endDate: undefined,
+	stillEngaged: false,
+	type: 'Extracurricular',
+	credentialId: undefined,
+	credentialUrl: undefined,
+});
+
+const filteredCertificates = computed(() => {
+	const filter = certificateFilter.value.trim().toLowerCase();
+	if (!filter) return certificates.value;
+	return certificates.value.filter(c =>
+		c.name.toLowerCase().includes(filter) ||
+		c.type.toLowerCase().includes(filter) ||
+		c.institutionName.toLowerCase().includes(filter)
+	);
+});
+
+async function loadCertificates() {
+	if (!resumeId) return;
+	loadingCertificates.value = true;
+	const result = await getCertificatesAsync(resumeId);
+	loadingCertificates.value = false;
+	if (result.succeeded && result.data) certificates.value = result.data;
+}
+
+function validateForm(): boolean {
+	const errors: string[] = [];
+	if (!formCertificate.name?.trim()) errors.push('Nome obrigatório.');
+	if (!formCertificate.description?.trim()) errors.push('Descrição obrigatória.');
+	if (!formCertificate.institutionName?.trim()) errors.push('Instituição obrigatória.');
+	if (!formCertificate.startDate) errors.push('Data de início obrigatória.');
+	if (formCertificate.startDate && formCertificate.endDate && formCertificate.endDate < formCertificate.startDate) errors.push('Data de término não pode ser anterior à data de início.');
+	if (!formCertificate.type?.trim()) errors.push('Tipo obrigatório.');
+	formErrors.value = errors;
+	return !errors.length;
+}
+
+function resetForm() {
+	formCertificate.name = '';
+	formCertificate.description = '';
+	formCertificate.institutionName = '';
+	formCertificate.location = '';
+	formCertificate.startDate = new Date().toISOString().slice(0, 10);
+	formCertificate.endDate = undefined;
+	formCertificate.stillEngaged = false;
+	formCertificate.type = 'Extracurricular';
+	formCertificate.credentialId = undefined;
+	formCertificate.credentialUrl = undefined;
+	editingCertificate.value = null;
+	formErrors.value = [];
+}
+
+function startEdit(certificate: ReadCertificateModel) {
+	editingCertificate.value = certificate;
+	openCreation.value = true;
+	formCertificate.name = certificate.name;
+	formCertificate.description = certificate.description;
+	formCertificate.institutionName = certificate.institutionName;
+	formCertificate.location = certificate.location ?? '';
+	formCertificate.startDate = certificate.startDate;
+	formCertificate.endDate = certificate.endDate ?? undefined;
+	formCertificate.stillEngaged = certificate.stillEngaged;
+	formCertificate.type = certificate.type;
+	formCertificate.credentialId = certificate.credentialId;
+	formCertificate.credentialUrl = certificate.credentialUrl;
+}
+
+async function submitCertificate() {
+	if (!validateForm() || !resumeId) return;
+
+	if (editingCertificate.value) {
+		const payload: UpdateCertificateModel = {
+			id: editingCertificate.value.id,
+			name: formCertificate.name,
+			description: formCertificate.description,
+			institutionName: formCertificate.institutionName,
+			location: formCertificate.location,
+			isRemote: formCertificate.isRemote,
+			startDate: formCertificate.startDate,
+			endDate: formCertificate.endDate,
+			stillEngaged: formCertificate.stillEngaged,
+			type: formCertificate.type,
+			credentialId: formCertificate.credentialId,
+			credentialUrl: formCertificate.credentialUrl,
+		};
+		const result = await updateCertificateAsync(resumeId, editingCertificate.value.id, payload);
+		if (result.succeeded && result.data) {
+			const idx = certificates.value.findIndex(c => c.id === result.data.id);
+			if (idx >= 0) certificates.value[idx] = result.data;
+			resetForm();
+			openCreation.value = false;
+		}
+		return;
+	}
+
+	const payload: AddCertificateModel = {
+		resumeId,
+		name: formCertificate.name ?? '',
+		description: formCertificate.description ?? '',
+		institutionName: formCertificate.institutionName ?? '',
+		location: formCertificate.location,
+		isRemote: formCertificate.isRemote ?? false,
+		startDate: formCertificate.startDate ?? new Date().toISOString().slice(0, 10),
+		endDate: formCertificate.endDate,
+		stillEngaged: formCertificate.stillEngaged ?? false,
+		type: formCertificate.type ?? 'Extracurricular',
+		credentialId: formCertificate.credentialId,
+		credentialUrl: formCertificate.credentialUrl,
+	};
+
+	const result = await createCertificateAsync(resumeId, payload);
+	if (result.succeeded && result.data) {
+		certificates.value.push(result.data);
+		resetForm();
+		openCreation.value = false;
+	}
+}
+
+async function removeCertificate(id: number) {
+	if (!resumeId) return;
+	const result = await deleteCertificateAsync(resumeId, id);
+	if (result.succeeded) {
+		certificates.value = certificates.value.filter(c => c.id !== id);
+	}
+}
+
+function closeForm() {
+	openCreation.value = false;
+	resetForm();
+}
+
+onMounted(loadCertificates);
 </script>


### PR DESCRIPTION
## Descrição

Implementação completa da feature de Inclusão de Certificado Extracurricular no currículo, cobrindo backend, frontend e testes automatizados, conforme especificado na issue #22.

---

## Issue relacionada

Fecha #22

---

## O que foi implementado

### Backend (`backend/`)

- **`CertificateType.cs`** — Adicionado novo valor `Extracurricular` ao enum `CertificateType`.
- **`CertificatesController.cs`** — CRUD completo de certificados:
    - `GET /certificates` — listagem com suporte a filtro por tipo
    - `POST /certificates` — criação
    - `PUT /certificates/{id}` — edição
    - `DELETE /certificates/{id}` — exclusão
    - Autorização por dono do currículo em todos os endpoints
- **`CertificateService.cs`** — Camada de serviço com lógica de negócio e persistência.
- **`CertificateValidator.cs`** — Validação de domínio: campos obrigatórios, formato de dados e regras de negócio para certificados.

### Frontend (`frontend/resumi-frontend/`)

- **`resume-form.vue`** — Integração da seção de certificados no editor do currículo:
    - Listagem de certificados existentes
    - Formulário de criação e edição
    - Confirmação e exclusão
    - Filtro por tipo
- **`certificate-service.ts`** — Serviço de API no frontend para consumo dos novos endpoints.
- **`app/data/api/certificate-model.ts`** — DTOs/modelos tipados alinhados ao contrato do backend.

### Testes (`backend/TestResumi/`)

- Testes de unidade para `CertificatesController` e `CertificateValidator`.
- Todos os testes passando: `dotnet test`
- Build do frontend sem erros:

---

## Critérios de aceite atendidos

- [x] Endpoints de CRUD para certificados funcionando
- [x] Validação de entrada e tratamento de erros
- [x] Autorização por dono do currículo
- [x] Integração frontend com os novos endpoints
- [x] Testes automatizados rodando

---

## Como testar

**Backend:**
```bash
cd backend && dotnet test
```

**Frontend:**
```bash
cd frontend/resumi-frontend && yarn build
```

**Fluxo manual (usuário logado):**
1. Abrir o editor de currículo
2. Navegar até a seção de certificados
3. Adicionar um certificado com tipo **extracurricular**
4. Editar e excluir o certificado criado
5. Confirmar persistência ao recarregar o editor

---

## Arquivos alterados

| Arquivo | Tipo de mudança |
|---|---|
| `backend/Domain/Enums/CertificateType.cs` | Modificado |
| `backend/Api/Controllers/CertificatesController.cs` | Adicionado |
| `backend/Application/Services/CertificateService.cs` | Adicionado |
| `backend/Domain/Validators/CertificateValidator.cs` | Adicionado |
| `backend/TestResumi/Controllers/CertificatesControllerTests.cs` | Adicionado |
| `backend/TestResumi/Validators/CertificateValidatorTests.cs` | Adicionado |
| `frontend/resumi-frontend/components/resume-form.vue` | Modificado |
| `frontend/resumi-frontend/services/certificate-service.ts` | Adicionado |
| `frontend/resumi-frontend/app/data/api/certificate-model.ts` | Adicionado/Modificado |